### PR TITLE
Use pip to install tensorflow 1.1

### DIFF
--- a/dl/tensorflow/1.1.0/Dockerfile-py2
+++ b/dl/tensorflow/1.1.0/Dockerfile-py2
@@ -1,32 +1,12 @@
-FROM floydhub/dl-base:latest-py2
+FROM floydhub/dl-base:v1-py2
 MAINTAINER Floyd Labs "support@floydhub.com"
 
-ARG TENSORFLOW_VERSION=v1.1.0
-ARG KERAS_VERSION=2.0.3
+ARG TENSORFLOW_VERSION=1.1.0
+ARG KERAS_VERSION=2.0.4
 
-# RUN pip install --upgrade tensorflow==${TENSORFLOW_VERSION}
+ARG TF_BINARY_URL=https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-${TENSORFLOW_VERSION}-cp27-none-linux_x86_64.whl
 
-# Download and build TensorFlow.
-# Adapted from https://github.com/tensorflow/tensorflow/blob/master/tensorflow/tools/docker/Dockerfile.devel
-
-RUN git clone https://github.com/tensorflow/tensorflow.git --branch ${TENSORFLOW_VERSION} --single-branch
-WORKDIR /tensorflow
-
-ENV CI_BUILD_PYTHON python
-
-RUN tensorflow/tools/ci_build/builds/configured CPU
-
-# NOTE: This command uses special flags to build an optimized image for AWS machines.
-# This image might *NOT* work on other machines
-RUN bazel build -c opt --copt=-msse3 --copt=-msse4.1 --copt=-msse4.2 --copt=-mavx --copt=-mavx2 --copt=-mfma tensorflow/tools/pip_package:build_pip_package
-
-RUN bazel-bin/tensorflow/tools/pip_package/build_pip_package /tmp/pip && \
-    pip --no-cache-dir install --upgrade /tmp/pip/tensorflow-*.whl && \
-    rm -rf /tmp/pip && \
-    rm -rf /root/.cache
-# Clean up pip wheel and Bazel cache when done.
-
-WORKDIR /
+RUN pip --no-cache-dir install --upgrade ${TF_BINARY_URL}
 
 # Install Keras
 RUN pip --no-cache-dir install git+git://github.com/fchollet/keras.git@${KERAS_VERSION}

--- a/dl/tensorflow/1.1.0/Dockerfile-py2.gpu
+++ b/dl/tensorflow/1.1.0/Dockerfile-py2.gpu
@@ -1,36 +1,12 @@
-FROM floydhub/dl-base:latest-gpu-py2
+FROM floydhub/dl-base:v1-gpu-py2
 MAINTAINER Floyd Labs "support@floydhub.com"
 
-ARG TENSORFLOW_VERSION=v1.1.0
-ARG KERAS_VERSION=2.0.3
+ARG TENSORFLOW_VERSION=1.1.0
+ARG KERAS_VERSION=2.0.4
 
-# RUN pip install --upgrade tensorflow-gpu==1.0.0
+ARG TF_BINARY_URL=https://storage.googleapis.com/tensorflow/linux/gpu/tensorflow_gpu-${TENSORFLOW_VERSION}-cp27-none-linux_x86_64.whl
 
-# Download and build TensorFlow.
-# Adapted from https://github.com/tensorflow/tensorflow/blob/master/tensorflow/tools/docker/Dockerfile.devel-gpu
-
-RUN git clone https://github.com/tensorflow/tensorflow.git --branch ${TENSORFLOW_VERSION} --single-branch
-WORKDIR /tensorflow
-
-# Configure the build for our CUDA configuration.
-ENV CI_BUILD_PYTHON python
-ENV LD_LIBRARY_PATH /usr/local/cuda/extras/CUPTI/lib64:$LD_LIBRARY_PATH
-ENV TF_NEED_CUDA 1
-ENV TF_CUDA_COMPUTE_CAPABILITIES=3.0,3.5,5.2,6.0,6.1
-
-RUN tensorflow/tools/ci_build/builds/configured GPU
-
-# NOTE: This command uses special flags to build an optimized image for AWS machines.
-# This image might *NOT* work on other machines
-RUN bazel build -c opt --copt=-msse3 --copt=-msse4.1 --copt=-msse4.2 --copt=-mavx --copt=-mavx2 --copt=-mfma --config=cuda tensorflow/tools/pip_package:build_pip_package
-
-RUN bazel-bin/tensorflow/tools/pip_package/build_pip_package /tmp/pip && \
-    pip --no-cache-dir install --upgrade /tmp/pip/tensorflow-*.whl && \
-    rm -rf /tmp/pip && \
-    rm -rf /root/.cache
-# Clean up pip wheel and Bazel cache when done.
-
-WORKDIR /
+RUN pip --no-cache-dir install --upgrade ${TF_BINARY_URL}
 
 # Install Keras
 RUN pip --no-cache-dir install git+git://github.com/fchollet/keras.git@${KERAS_VERSION}

--- a/dl/tensorflow/1.1.0/Dockerfile-py3
+++ b/dl/tensorflow/1.1.0/Dockerfile-py3
@@ -1,32 +1,12 @@
-FROM floydhub/dl-base:latest-py3
+FROM floydhub/dl-base:v1-py3
 MAINTAINER Floyd Labs "support@floydhub.com"
 
-ARG TENSORFLOW_VERSION=v1.1.0
-ARG KERAS_VERSION=2.0.3
+ARG TENSORFLOW_VERSION=1.1.0
+ARG KERAS_VERSION=2.0.4
 
-# RUN pip install --upgrade tensorflow==${TENSORFLOW_VERSION}
+ARG TF_BINARY_URL=https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-${TENSORFLOW_VERSION}-cp35-cp35m-linux_x86_64.whl
 
-# Download and build TensorFlow.
-# Adapted from https://github.com/tensorflow/tensorflow/blob/master/tensorflow/tools/docker/Dockerfile.devel
-
-RUN git clone https://github.com/tensorflow/tensorflow.git --branch ${TENSORFLOW_VERSION} --single-branch
-WORKDIR /tensorflow
-
-ENV CI_BUILD_PYTHON python
-
-RUN tensorflow/tools/ci_build/builds/configured CPU
-
-# NOTE: This command uses special flags to build an optimized image for AWS machines.
-# This image might *NOT* work on other machines
-RUN bazel build -c opt --copt=-msse3 --copt=-msse4.1 --copt=-msse4.2 --copt=-mavx --copt=-mavx2 --copt=-mfma tensorflow/tools/pip_package:build_pip_package
-
-RUN bazel-bin/tensorflow/tools/pip_package/build_pip_package /tmp/pip && \
-    pip --no-cache-dir install --upgrade /tmp/pip/tensorflow-*.whl && \
-    rm -rf /tmp/pip && \
-    rm -rf /root/.cache
-# Clean up pip wheel and Bazel cache when done.
-
-WORKDIR /
+RUN pip --no-cache-dir install --upgrade ${TF_BINARY_URL}
 
 # Install Keras
 RUN pip --no-cache-dir install git+git://github.com/fchollet/keras.git@${KERAS_VERSION}

--- a/dl/tensorflow/1.1.0/Dockerfile-py3.gpu
+++ b/dl/tensorflow/1.1.0/Dockerfile-py3.gpu
@@ -1,36 +1,12 @@
-FROM floydhub/dl-base:latest-gpu-py3
+FROM floydhub/dl-base:v1-gpu-py3
 MAINTAINER Floyd Labs "support@floydhub.com"
 
-ARG TENSORFLOW_VERSION=v1.1.0
-ARG KERAS_VERSION=2.0.3
+ARG TENSORFLOW_VERSION=1.1.0
+ARG KERAS_VERSION=2.0.4
 
-# RUN pip install --upgrade tensorflow-gpu==1.0.0
+ARG TF_BINARY_URL=https://storage.googleapis.com/tensorflow/linux/gpu/tensorflow_gpu-${TENSORFLOW_VERSION}-cp35-cp35m-linux_x86_64.whl
 
-# Download and build TensorFlow.
-# Adapted from https://github.com/tensorflow/tensorflow/blob/master/tensorflow/tools/docker/Dockerfile.devel-gpu
-
-RUN git clone https://github.com/tensorflow/tensorflow.git --branch ${TENSORFLOW_VERSION} --single-branch
-WORKDIR /tensorflow
-
-# Configure the build for our CUDA configuration.
-ENV CI_BUILD_PYTHON python
-ENV LD_LIBRARY_PATH /usr/local/cuda/extras/CUPTI/lib64:$LD_LIBRARY_PATH
-ENV TF_NEED_CUDA 1
-ENV TF_CUDA_COMPUTE_CAPABILITIES=3.0,3.5,5.2,6.0,6.1
-
-RUN tensorflow/tools/ci_build/builds/configured GPU
-
-# NOTE: This command uses special flags to build an optimized image for AWS machines.
-# This image might *NOT* work on other machines
-RUN bazel build -c opt --copt=-msse3 --copt=-msse4.1 --copt=-msse4.2 --copt=-mavx --copt=-mavx2 --copt=-mfma --config=cuda tensorflow/tools/pip_package:build_pip_package
-
-RUN bazel-bin/tensorflow/tools/pip_package/build_pip_package /tmp/pip && \
-    pip --no-cache-dir install --upgrade /tmp/pip/tensorflow-*.whl && \
-    rm -rf /tmp/pip && \
-    rm -rf /root/.cache
-# Clean up pip wheel and Bazel cache when done.
-
-WORKDIR /
+RUN pip --no-cache-dir install --upgrade ${TF_BINARY_URL}
 
 # Install Keras
 RUN pip --no-cache-dir install git+git://github.com/fchollet/keras.git@${KERAS_VERSION}


### PR DESCRIPTION
This is a temporary fix to get the 1.1 version out. Will revert this back by running floydker after this.