### PR TITLE
Changed theano to new backend

### DIFF
--- a/dl/theano/0.9.0/Dockerfile-py2.gpu
+++ b/dl/theano/0.9.0/Dockerfile-py2.gpu
@@ -8,8 +8,8 @@ ARG KERAS_VERSION=2.0.3
 # Install Theano and set up Theano config (.theanorc) for CUDA and OpenBLAS
 RUN pip --no-cache-dir install git+git://github.com/Theano/Theano.git@${THEANO_VERSION} && \
 	\
-	echo "[global]\ndevice=gpu\nfloatX=float32\noptimizer_including=cudnn\nmode=FAST_RUN \
-		\n[lib]\ncnmem=0.95 \
+	echo "[global]\ndevice=cuda\nfloatX=float32\noptimizer_including=cudnn\nmode=FAST_RUN \
+		\n[gpuarray]\preallocate=0.95 \
 		\n[nvcc]\nfastmath=True \
 		\n[blas]\nldflag = -L/usr/lib/openblas-base -lopenblas \
 		\n[DebugMode]\ncheck_finite=1" \

--- a/dl/theano/0.9.0/Dockerfile-py3.gpu
+++ b/dl/theano/0.9.0/Dockerfile-py3.gpu
@@ -8,8 +8,8 @@ ARG KERAS_VERSION=2.0.3
 # Install Theano and set up Theano config (.theanorc) for CUDA and OpenBLAS
 RUN pip --no-cache-dir install git+git://github.com/Theano/Theano.git@${THEANO_VERSION} && \
 	\
-	echo "[global]\ndevice=gpu\nfloatX=float32\noptimizer_including=cudnn\nmode=FAST_RUN \
-		\n[lib]\ncnmem=0.95 \
+	echo "[global]\ndevice=cuda\nfloatX=float32\noptimizer_including=cudnn\nmode=FAST_RUN \
+		\n[gpuarray]\preallocate=0.95 \
 		\n[nvcc]\nfastmath=True \
 		\n[blas]\nldflag = -L/usr/lib/openblas-base -lopenblas \
 		\n[DebugMode]\ncheck_finite=1" \


### PR DESCRIPTION
Thank you @saiprashanths for updating theano to the latest version. However from this version, theano has stopped supporting the old backend and in the current github master, the old backend has been removed completely. Also, certain new additions like `BatchNormalization` fails to adapt to the old backend. In this PR, I have changed the environment variable to use the new backend. The documentation can be found [here](http://deeplearning.net/software/theano/tutorial/using_gpu.html)

Ramana