### PR TITLE
Add torchvision version deps

### DIFF
--- a/dl/pytorch/0.1.12/Dockerfile-py2
+++ b/dl/pytorch/0.1.12/Dockerfile-py2
@@ -3,7 +3,6 @@ MAINTAINER Floyd Labs "support@floydhub.com"
 
 RUN pip --no-cache-dir install --upgrade http://download.pytorch.org/whl/cu80/torch-0.1.12.post1-cp27-none-linux_x86_64.whl \
     tensorboardX
-
 # install torch vision from source for dataloader bug fix
 # ref: https://github.com/junyanz/pytorch-CycleGAN-and-pix2pix/issues/63
 RUN git clone https://github.com/pytorch/vision \

--- a/dl/pytorch/0.1.12/Dockerfile-py2.gpu
+++ b/dl/pytorch/0.1.12/Dockerfile-py2.gpu
@@ -3,7 +3,6 @@ MAINTAINER Floyd Labs "support@floydhub.com"
 
 RUN pip --no-cache-dir install --upgrade http://download.pytorch.org/whl/cu80/torch-0.1.12.post1-cp27-none-linux_x86_64.whl \
     tensorboardX
-
 # install torch vision from source for dataloader bug fix
 # ref: https://github.com/junyanz/pytorch-CycleGAN-and-pix2pix/issues/63
 RUN git clone https://github.com/pytorch/vision \

--- a/dl/pytorch/0.1.12/Dockerfile-py3
+++ b/dl/pytorch/0.1.12/Dockerfile-py3
@@ -3,7 +3,6 @@ MAINTAINER Floyd Labs "support@floydhub.com"
 
 RUN pip --no-cache-dir install --upgrade http://download.pytorch.org/whl/cu80/torch-0.1.12.post1-cp35-cp35m-linux_x86_64.whl \
     tensorboardX
-
 # install torch vision from source for dataloader bug fix
 # ref: https://github.com/junyanz/pytorch-CycleGAN-and-pix2pix/issues/63
 RUN git clone https://github.com/pytorch/vision \

--- a/dl/pytorch/0.1.12/Dockerfile-py3.gpu
+++ b/dl/pytorch/0.1.12/Dockerfile-py3.gpu
@@ -3,7 +3,6 @@ MAINTAINER Floyd Labs "support@floydhub.com"
 
 RUN pip --no-cache-dir install --upgrade http://download.pytorch.org/whl/cu80/torch-0.1.12.post1-cp35-cp35m-linux_x86_64.whl \
     tensorboardX
-
 # install torch vision from source for dataloader bug fix
 # ref: https://github.com/junyanz/pytorch-CycleGAN-and-pix2pix/issues/63
 RUN git clone https://github.com/pytorch/vision \

--- a/dl/pytorch/0.2.0/Dockerfile-py2
+++ b/dl/pytorch/0.2.0/Dockerfile-py2
@@ -3,7 +3,6 @@ MAINTAINER Floyd Labs "support@floydhub.com"
 
 RUN pip --no-cache-dir install --upgrade http://download.pytorch.org/whl/cu80/torch-0.2.0.post3-cp27-cp27mu-manylinux1_x86_64.whl \
     tensorboardX
-
 # install torch vision from source for dataloader bug fix
 # ref: https://github.com/junyanz/pytorch-CycleGAN-and-pix2pix/issues/63
 RUN git clone https://github.com/pytorch/vision \

--- a/dl/pytorch/0.2.0/Dockerfile-py2.gpu
+++ b/dl/pytorch/0.2.0/Dockerfile-py2.gpu
@@ -3,7 +3,6 @@ MAINTAINER Floyd Labs "support@floydhub.com"
 
 RUN pip --no-cache-dir install --upgrade http://download.pytorch.org/whl/cu80/torch-0.2.0.post3-cp27-cp27mu-manylinux1_x86_64.whl \
     tensorboardX
-
 # install torch vision from source for dataloader bug fix
 # ref: https://github.com/junyanz/pytorch-CycleGAN-and-pix2pix/issues/63
 RUN git clone https://github.com/pytorch/vision \

--- a/dl/pytorch/0.2.0/Dockerfile-py3
+++ b/dl/pytorch/0.2.0/Dockerfile-py3
@@ -3,7 +3,6 @@ MAINTAINER Floyd Labs "support@floydhub.com"
 
 RUN pip --no-cache-dir install --upgrade http://download.pytorch.org/whl/cu80/torch-0.2.0.post3-cp36-cp36m-manylinux1_x86_64.whl \
     tensorboardX
-
 # install torch vision from source for dataloader bug fix
 # ref: https://github.com/junyanz/pytorch-CycleGAN-and-pix2pix/issues/63
 RUN git clone https://github.com/pytorch/vision \

--- a/dl/pytorch/0.2.0/Dockerfile-py3.gpu
+++ b/dl/pytorch/0.2.0/Dockerfile-py3.gpu
@@ -3,7 +3,6 @@ MAINTAINER Floyd Labs "support@floydhub.com"
 
 RUN pip --no-cache-dir install --upgrade http://download.pytorch.org/whl/cu80/torch-0.2.0.post3-cp36-cp36m-manylinux1_x86_64.whl \
     tensorboardX
-
 # install torch vision from source for dataloader bug fix
 # ref: https://github.com/junyanz/pytorch-CycleGAN-and-pix2pix/issues/63
 RUN git clone https://github.com/pytorch/vision \

--- a/dl/pytorch/0.3.0/Dockerfile-py2
+++ b/dl/pytorch/0.3.0/Dockerfile-py2
@@ -2,13 +2,5 @@ FROM floydhub/dl-base:2.1.0-py2.22
 MAINTAINER Floyd Labs "support@floydhub.com"
 
 RUN pip --no-cache-dir install --upgrade http://download.pytorch.org/whl/cu80/torch-0.3.0.post4-cp27-cp27mu-linux_x86_64.whl \
-    tensorboardX
-
-# install torch vision from source for dataloader bug fix
-# ref: https://github.com/junyanz/pytorch-CycleGAN-and-pix2pix/issues/63
-RUN git clone https://github.com/pytorch/vision \
-    && cd vision \
-    && git checkout 7492fae4c2cd16fb2783dce7e7583d7245cfbe92 \
-    && python setup.py install \
-    && cd .. \
-    && rm -rf vision
+    tensorboardX \
+    torchvision==0.2.0

--- a/dl/pytorch/0.3.0/Dockerfile-py2.gpu.cuda8cudnn6
+++ b/dl/pytorch/0.3.0/Dockerfile-py2.gpu.cuda8cudnn6
@@ -2,13 +2,5 @@ FROM floydhub/dl-base:2.1.0-gpu-py2.22
 MAINTAINER Floyd Labs "support@floydhub.com"
 
 RUN pip --no-cache-dir install --upgrade http://download.pytorch.org/whl/cu80/torch-0.3.0.post4-cp27-cp27mu-linux_x86_64.whl \
-    tensorboardX
-
-# install torch vision from source for dataloader bug fix
-# ref: https://github.com/junyanz/pytorch-CycleGAN-and-pix2pix/issues/63
-RUN git clone https://github.com/pytorch/vision \
-    && cd vision \
-    && git checkout 7492fae4c2cd16fb2783dce7e7583d7245cfbe92 \
-    && python setup.py install \
-    && cd .. \
-    && rm -rf vision
+    tensorboardX \
+    torchvision==0.2.0

--- a/dl/pytorch/0.3.0/Dockerfile-py2.gpu.cuda9cudnn7
+++ b/dl/pytorch/0.3.0/Dockerfile-py2.gpu.cuda9cudnn7
@@ -2,13 +2,5 @@ FROM floydhub/dl-base:3.0.0-gpu-py2.22
 MAINTAINER Floyd Labs "support@floydhub.com"
 
 RUN pip --no-cache-dir install --upgrade http://download.pytorch.org/whl/cu90/torch-0.3.0.post4-cp27-cp27mu-linux_x86_64.whl \
-    tensorboardX
-
-# install torch vision from source for dataloader bug fix
-# ref: https://github.com/junyanz/pytorch-CycleGAN-and-pix2pix/issues/63
-RUN git clone https://github.com/pytorch/vision \
-    && cd vision \
-    && git checkout 7492fae4c2cd16fb2783dce7e7583d7245cfbe92 \
-    && python setup.py install \
-    && cd .. \
-    && rm -rf vision
+    tensorboardX \
+    torchvision==0.2.0

--- a/dl/pytorch/0.3.0/Dockerfile-py3
+++ b/dl/pytorch/0.3.0/Dockerfile-py3
@@ -2,13 +2,5 @@ FROM floydhub/dl-base:2.1.0-py3.22
 MAINTAINER Floyd Labs "support@floydhub.com"
 
 RUN pip --no-cache-dir install --upgrade http://download.pytorch.org/whl/cu80/torch-0.3.0.post4-cp36-cp36m-linux_x86_64.whl \
-    tensorboardX
-
-# install torch vision from source for dataloader bug fix
-# ref: https://github.com/junyanz/pytorch-CycleGAN-and-pix2pix/issues/63
-RUN git clone https://github.com/pytorch/vision \
-    && cd vision \
-    && git checkout 7492fae4c2cd16fb2783dce7e7583d7245cfbe92 \
-    && python setup.py install \
-    && cd .. \
-    && rm -rf vision
+    tensorboardX \
+    torchvision==0.2.0

--- a/dl/pytorch/0.3.0/Dockerfile-py3.gpu.cuda8cudnn6
+++ b/dl/pytorch/0.3.0/Dockerfile-py3.gpu.cuda8cudnn6
@@ -2,13 +2,5 @@ FROM floydhub/dl-base:2.1.0-gpu-py3.22
 MAINTAINER Floyd Labs "support@floydhub.com"
 
 RUN pip --no-cache-dir install --upgrade http://download.pytorch.org/whl/cu80/torch-0.3.0.post4-cp36-cp36m-linux_x86_64.whl \
-    tensorboardX
-
-# install torch vision from source for dataloader bug fix
-# ref: https://github.com/junyanz/pytorch-CycleGAN-and-pix2pix/issues/63
-RUN git clone https://github.com/pytorch/vision \
-    && cd vision \
-    && git checkout 7492fae4c2cd16fb2783dce7e7583d7245cfbe92 \
-    && python setup.py install \
-    && cd .. \
-    && rm -rf vision
+    tensorboardX \
+    torchvision==0.2.0

--- a/dl/pytorch/0.3.0/Dockerfile-py3.gpu.cuda9cudnn7
+++ b/dl/pytorch/0.3.0/Dockerfile-py3.gpu.cuda9cudnn7
@@ -2,13 +2,5 @@ FROM floydhub/dl-base:3.0.0-gpu-py3.22
 MAINTAINER Floyd Labs "support@floydhub.com"
 
 RUN pip --no-cache-dir install --upgrade http://download.pytorch.org/whl/cu90/torch-0.3.0.post4-cp36-cp36m-linux_x86_64.whl \
-    tensorboardX
-
-# install torch vision from source for dataloader bug fix
-# ref: https://github.com/junyanz/pytorch-CycleGAN-and-pix2pix/issues/63
-RUN git clone https://github.com/pytorch/vision \
-    && cd vision \
-    && git checkout 7492fae4c2cd16fb2783dce7e7583d7245cfbe92 \
-    && python setup.py install \
-    && cd .. \
-    && rm -rf vision
+    tensorboardX \
+    torchvision==0.2.0

--- a/dl/pytorch/matrix.yml
+++ b/dl/pytorch/matrix.yml
@@ -71,6 +71,7 @@
   _platform: linux
   _template: pytorch-0.x.x.jinja
   _version: 0.3.0.post4
+  _vision_version: 0.2.0
   py2:
     arch: cpu
     baseimg: floydhub/dl-base:2.1.0-py2.22

--- a/dl/pytorch/pytorch-0.x.x.jinja
+++ b/dl/pytorch/pytorch-0.x.x.jinja
@@ -2,8 +2,9 @@
 
 {% block content %}
 RUN pip --no-cache-dir install --upgrade http://download.pytorch.org/whl/{{ cuda_version }}/torch-{{ _version }}-{{ cpver }}-{{ _platform }}_x86_64.whl \
-    tensorboardX
-
+    tensorboardX{% if _vision_version is defined %} \
+    torchvision=={{ _vision_version }}
+{% else %}
 # install torch vision from source for dataloader bug fix
 # ref: https://github.com/junyanz/pytorch-CycleGAN-and-pix2pix/issues/63
 RUN git clone https://github.com/pytorch/vision \
@@ -12,5 +13,6 @@ RUN git clone https://github.com/pytorch/vision \
     && python setup.py install \
     && cd .. \
     && rm -rf vision
+{% endif %}
 
 {%- endblock %}


### PR DESCRIPTION
Update the `torchvision` package to the latest version for the recent pytorch version. I've left the old one for the pytorch versions < 0.3.0.