### PR TITLE
Add pytorch 0.3.1

### DIFF
--- a/dl/pytorch/0.3.1/Dockerfile-py2
+++ b/dl/pytorch/0.3.1/Dockerfile-py2
@@ -1,0 +1,6 @@
+FROM floydhub/tensorflow:1.5.0-py2_aws.22
+MAINTAINER Floyd Labs "support@floydhub.com"
+
+RUN pip --no-cache-dir install --upgrade http://download.pytorch.org/whl/cu90/torch-0.3.1-cp27-cp27mu-linux_x86_64.whl \
+    tensorboardX \
+    torchvision==0.2.0

--- a/dl/pytorch/0.3.1/Dockerfile-py2.gpu.cuda9cudnn7
+++ b/dl/pytorch/0.3.1/Dockerfile-py2.gpu.cuda9cudnn7
@@ -1,0 +1,6 @@
+FROM floydhub/tensorflow:1.5.0-gpu.cuda9cudnn7-py2_aws.22
+MAINTAINER Floyd Labs "support@floydhub.com"
+
+RUN pip --no-cache-dir install --upgrade http://download.pytorch.org/whl/cu90/torch-0.3.1-cp27-cp27mu-linux_x86_64.whl \
+    tensorboardX \
+    torchvision==0.2.0

--- a/dl/pytorch/0.3.1/Dockerfile-py3
+++ b/dl/pytorch/0.3.1/Dockerfile-py3
@@ -1,0 +1,6 @@
+FROM floydhub/tensorflow:1.5.0-py3_aws.22
+MAINTAINER Floyd Labs "support@floydhub.com"
+
+RUN pip --no-cache-dir install --upgrade http://download.pytorch.org/whl/cu90/torch-0.3.1-cp36-cp36m-linux_x86_64.whl \
+    tensorboardX \
+    torchvision==0.2.0

--- a/dl/pytorch/0.3.1/Dockerfile-py3.gpu.cuda9cudnn7
+++ b/dl/pytorch/0.3.1/Dockerfile-py3.gpu.cuda9cudnn7
@@ -1,0 +1,6 @@
+FROM floydhub/tensorflow:1.5.0-gpu.cuda9cudnn7-py3_aws.22
+MAINTAINER Floyd Labs "support@floydhub.com"
+
+RUN pip --no-cache-dir install --upgrade http://download.pytorch.org/whl/cu90/torch-0.3.1-cp36-cp36m-linux_x86_64.whl \
+    tensorboardX \
+    torchvision==0.2.0

--- a/dl/pytorch/matrix.yml
+++ b/dl/pytorch/matrix.yml
@@ -109,8 +109,39 @@
     cuda_version: cu90
     _test: tests/test.sh
 
+# The new images are built from Tensorflow to support TensorboardX
+'0.3.1':
+  _platform: linux
+  _template: pytorch-0.x.x.jinja
+  _version: 0.3.1
+  _vision_version: 0.2.0
+  py2:
+    arch: cpu
+    baseimg: floydhub/tensorflow:1.5.0-py2_aws.22
+    cpver: cp27-cp27mu
+    cuda_version: cu90
+    _test: tests/test.sh
+  py3:
+    arch: cpu
+    baseimg: floydhub/tensorflow:1.5.0-py3_aws.22
+    cpver: cp36-cp36m
+    cuda_version: cu90
+    _test: tests/test.sh
+  py2.gpu.cuda9cudnn7:
+    arch: gpu
+    baseimg: floydhub/tensorflow:1.5.0-gpu.cuda9cudnn7-py2_aws.22
+    cpver: cp27-cp27mu
+    cuda_version: cu90
+    _test: tests/test.sh
+  py3.gpu.cuda9cudnn7:
+    arch: gpu
+    baseimg: floydhub/tensorflow:1.5.0-gpu.cuda9cudnn7-py3_aws.22
+    cpver: cp36-cp36m
+    cuda_version: cu90
+    _test: tests/test.sh
 
 $render:
-  - '0.1.12'
-  - '0.2.0'
-  - '0.3.0'
+  #- '0.1.12'
+  #- '0.2.0'
+  #- '0.3.0'
+  - '0.3.1'

--- a/floydker/README.md
+++ b/floydker/README.md
@@ -36,6 +36,15 @@ Render dockerfiles for a specific project:
 floydker render --project tensorflow ..
 ```
 
+### Build image
+
+Once the docker image is rendered, you can run `floydker build PATH_TO_RENDERED_DOCKER_FILE` to have it automatically build and tag the image.
+
+e.g Building and Tagging Pytorch 0.3.1 env as floydhub/pytorch:0.3.1-py3
+
+```bash
+floydker build ../dl/pytorch/0.3.1/Dockerfile-py3
+```
 
 ### Define tests for images
 
@@ -54,3 +63,6 @@ Just add a `_test` key under your target configuration. For example:
 If test script path is not absolute, it will be relative to matrix.yml. Test
 script's parent directory will be mounted into a test container under path
 `/build_test`, so it will only have access to files in its own directory.
+
+
+Run `floydker test PATH_TO_RENDERED_DOCKER_FILE` to test the image with predefined test scripts.


### PR DESCRIPTION
These envs are built from TF 1.5 to support TensorboardX.

I have already tested the py2 and py3 (CPU only) version locally. The GPU envs are built to support CUDA 9.