### PR TITLE
Add jupyter widget extension

### DIFF
--- a/dl/dl-base/3.1.0/Dockerfile-py2
+++ b/dl/dl-base/3.1.0/Dockerfile-py2
@@ -1,8 +1,13 @@
 FROM floydhub/dl-python:3.1.0-py2
 MAINTAINER Floyd Labs "support@floydhub.com"
 
-# Add Tensorboard
-RUN apt-get update && apt-get install -y supervisor \
+
+# Script to install the NodeSource Node.js 8.x LTS Carbon
+# repo onto a Debian or Ubuntu system.
+RUN wget -qO- https://deb.nodesource.com/setup_8.x | bash -
+
+# Install Nodejs and Add Tensorboard
+RUN apt-get update && apt-get install -y supervisor nodejs\
   && apt-get clean \
   && apt-get autoremove \
   && rm -rf /var/cache/apt/archives/* \
@@ -16,7 +21,6 @@ RUN apt-get update && apt-get install -y \
     && apt-get autoremove \
     && rm -rf /var/lib/apt/lists/* \
     && rm -rf /var/cache/apt/archives/*
-
 
 RUN pip --no-cache-dir install \
         pydot \
@@ -35,6 +39,10 @@ RUN pip --no-cache-dir install \
         annoy \
     && rm -rf /tmp/* /var/tmp/*
 
+
+# Install and Enable jupyter-widgets
+# jupyterlab-manager@0.35 doesn't work on JL v0.31.12
+RUN jupyter labextension install @jupyter-widgets/jupyterlab-manager@0.34
 
 # Install xgboost
 RUN git clone --recursive https://github.com/dmlc/xgboost \

--- a/dl/dl-base/3.1.0/Dockerfile-py2
+++ b/dl/dl-base/3.1.0/Dockerfile-py2
@@ -36,6 +36,7 @@ RUN pip --no-cache-dir install \
         tqdm \
         wheel \
         kaggle \
+        h5py==2.8.0rc1 \
         seaborn \
         plotly \
         annoy \

--- a/dl/dl-base/3.1.0/Dockerfile-py2
+++ b/dl/dl-base/3.1.0/Dockerfile-py2
@@ -36,6 +36,9 @@ RUN pip --no-cache-dir install \
         tqdm \
         wheel \
         kaggle-cli \
+        kaggle \
+        seaborn \
+        plotly \
         annoy \
     && rm -rf /tmp/* /var/tmp/*
 

--- a/dl/dl-base/3.1.0/Dockerfile-py2
+++ b/dl/dl-base/3.1.0/Dockerfile-py2
@@ -35,7 +35,6 @@ RUN pip --no-cache-dir install \
         spacy \
         tqdm \
         wheel \
-        kaggle-cli \
         kaggle \
         seaborn \
         plotly \

--- a/dl/dl-base/3.1.0/Dockerfile-py2.gpu
+++ b/dl/dl-base/3.1.0/Dockerfile-py2.gpu
@@ -1,8 +1,13 @@
 FROM floydhub/dl-python:3.1.0-gpu-py2
 MAINTAINER Floyd Labs "support@floydhub.com"
 
-# Add Tensorboard
-RUN apt-get update && apt-get install -y supervisor \
+
+# Script to install the NodeSource Node.js 8.x LTS Carbon
+# repo onto a Debian or Ubuntu system.
+RUN wget -qO- https://deb.nodesource.com/setup_8.x | bash -
+
+# Install Nodejs and Add Tensorboard
+RUN apt-get update && apt-get install -y supervisor nodejs\
   && apt-get clean \
   && apt-get autoremove \
   && rm -rf /var/cache/apt/archives/* \
@@ -16,7 +21,6 @@ RUN apt-get update && apt-get install -y \
     && apt-get autoremove \
     && rm -rf /var/lib/apt/lists/* \
     && rm -rf /var/cache/apt/archives/*
-
 
 RUN pip --no-cache-dir install \
         pydot \
@@ -35,6 +39,10 @@ RUN pip --no-cache-dir install \
         annoy \
     && rm -rf /tmp/* /var/tmp/*
 
+
+# Install and Enable jupyter-widgets
+# jupyterlab-manager@0.35 doesn't work on JL v0.31.12
+RUN jupyter labextension install @jupyter-widgets/jupyterlab-manager@0.34
 
 # Install xgboost
 RUN git clone --recursive https://github.com/dmlc/xgboost \

--- a/dl/dl-base/3.1.0/Dockerfile-py2.gpu
+++ b/dl/dl-base/3.1.0/Dockerfile-py2.gpu
@@ -36,6 +36,7 @@ RUN pip --no-cache-dir install \
         tqdm \
         wheel \
         kaggle \
+        h5py==2.8.0rc1 \
         seaborn \
         plotly \
         annoy \

--- a/dl/dl-base/3.1.0/Dockerfile-py2.gpu
+++ b/dl/dl-base/3.1.0/Dockerfile-py2.gpu
@@ -36,6 +36,9 @@ RUN pip --no-cache-dir install \
         tqdm \
         wheel \
         kaggle-cli \
+        kaggle \
+        seaborn \
+        plotly \
         annoy \
     && rm -rf /tmp/* /var/tmp/*
 

--- a/dl/dl-base/3.1.0/Dockerfile-py2.gpu
+++ b/dl/dl-base/3.1.0/Dockerfile-py2.gpu
@@ -35,7 +35,6 @@ RUN pip --no-cache-dir install \
         spacy \
         tqdm \
         wheel \
-        kaggle-cli \
         kaggle \
         seaborn \
         plotly \

--- a/dl/dl-base/3.1.0/Dockerfile-py3
+++ b/dl/dl-base/3.1.0/Dockerfile-py3
@@ -35,6 +35,7 @@ RUN pip --no-cache-dir install \
         tqdm \
         wheel \
         kaggle \
+        h5py==2.8.0rc1 \
         seaborn \
         plotly \
         annoy \

--- a/dl/dl-base/3.1.0/Dockerfile-py3
+++ b/dl/dl-base/3.1.0/Dockerfile-py3
@@ -34,7 +34,6 @@ RUN pip --no-cache-dir install \
         spacy \
         tqdm \
         wheel \
-        kaggle-cli \
         kaggle \
         seaborn \
         plotly \

--- a/dl/dl-base/3.1.0/Dockerfile-py3
+++ b/dl/dl-base/3.1.0/Dockerfile-py3
@@ -35,6 +35,9 @@ RUN pip --no-cache-dir install \
         tqdm \
         wheel \
         kaggle-cli \
+        kaggle \
+        seaborn \
+        plotly \
         annoy \
     && rm -rf /tmp/* /var/tmp/*
 

--- a/dl/dl-base/3.1.0/Dockerfile-py3
+++ b/dl/dl-base/3.1.0/Dockerfile-py3
@@ -1,8 +1,13 @@
 FROM floydhub/dl-python:3.1.0-py3
 MAINTAINER Floyd Labs "support@floydhub.com"
 
-# Add Tensorboard
-RUN apt-get update && apt-get install -y supervisor \
+
+# Script to install the NodeSource Node.js 8.x LTS Carbon
+# repo onto a Debian or Ubuntu system.
+RUN wget -qO- https://deb.nodesource.com/setup_8.x | bash -
+
+# Install Nodejs and Add Tensorboard
+RUN apt-get update && apt-get install -y supervisor nodejs\
   && apt-get clean \
   && apt-get autoremove \
   && rm -rf /var/cache/apt/archives/* \
@@ -16,7 +21,6 @@ RUN apt-get update && apt-get install -y \
     && apt-get autoremove \
     && rm -rf /var/lib/apt/lists/* \
     && rm -rf /var/cache/apt/archives/*
-
 
 RUN pip --no-cache-dir install \
         pydot \
@@ -34,6 +38,10 @@ RUN pip --no-cache-dir install \
         annoy \
     && rm -rf /tmp/* /var/tmp/*
 
+
+# Install and Enable jupyter-widgets
+# jupyterlab-manager@0.35 doesn't work on JL v0.31.12
+RUN jupyter labextension install @jupyter-widgets/jupyterlab-manager@0.34
 
 # Install xgboost
 RUN git clone --recursive https://github.com/dmlc/xgboost \

--- a/dl/dl-base/3.1.0/Dockerfile-py3.gpu
+++ b/dl/dl-base/3.1.0/Dockerfile-py3.gpu
@@ -35,6 +35,7 @@ RUN pip --no-cache-dir install \
         tqdm \
         wheel \
         kaggle \
+        h5py==2.8.0rc1 \
         seaborn \
         plotly \
         annoy \

--- a/dl/dl-base/3.1.0/Dockerfile-py3.gpu
+++ b/dl/dl-base/3.1.0/Dockerfile-py3.gpu
@@ -34,7 +34,6 @@ RUN pip --no-cache-dir install \
         spacy \
         tqdm \
         wheel \
-        kaggle-cli \
         kaggle \
         seaborn \
         plotly \

--- a/dl/dl-base/3.1.0/Dockerfile-py3.gpu
+++ b/dl/dl-base/3.1.0/Dockerfile-py3.gpu
@@ -35,6 +35,9 @@ RUN pip --no-cache-dir install \
         tqdm \
         wheel \
         kaggle-cli \
+        kaggle \
+        seaborn \
+        plotly \
         annoy \
     && rm -rf /tmp/* /var/tmp/*
 

--- a/dl/dl-base/3.1.0/Dockerfile-py3.gpu
+++ b/dl/dl-base/3.1.0/Dockerfile-py3.gpu
@@ -1,8 +1,13 @@
 FROM floydhub/dl-python:3.1.0-gpu-py3
 MAINTAINER Floyd Labs "support@floydhub.com"
 
-# Add Tensorboard
-RUN apt-get update && apt-get install -y supervisor \
+
+# Script to install the NodeSource Node.js 8.x LTS Carbon
+# repo onto a Debian or Ubuntu system.
+RUN wget -qO- https://deb.nodesource.com/setup_8.x | bash -
+
+# Install Nodejs and Add Tensorboard
+RUN apt-get update && apt-get install -y supervisor nodejs\
   && apt-get clean \
   && apt-get autoremove \
   && rm -rf /var/cache/apt/archives/* \
@@ -16,7 +21,6 @@ RUN apt-get update && apt-get install -y \
     && apt-get autoremove \
     && rm -rf /var/lib/apt/lists/* \
     && rm -rf /var/cache/apt/archives/*
-
 
 RUN pip --no-cache-dir install \
         pydot \
@@ -34,6 +38,10 @@ RUN pip --no-cache-dir install \
         annoy \
     && rm -rf /tmp/* /var/tmp/*
 
+
+# Install and Enable jupyter-widgets
+# jupyterlab-manager@0.35 doesn't work on JL v0.31.12
+RUN jupyter labextension install @jupyter-widgets/jupyterlab-manager@0.34
 
 # Install xgboost
 RUN git clone --recursive https://github.com/dmlc/xgboost \

--- a/dl/dl-base/dl-base-2.x.x.jinja
+++ b/dl/dl-base/dl-base-2.x.x.jinja
@@ -1,8 +1,13 @@
 {% extends "base.jinja" %}
 
 {% block content %}
-# Add Tensorboard
-RUN apt-get update && apt-get install -y supervisor \
+
+# Script to install the NodeSource Node.js 8.x LTS Carbon
+# repo onto a Debian or Ubuntu system.
+RUN wget -qO- https://deb.nodesource.com/setup_8.x | bash -
+
+# Install Nodejs and Add Tensorboard
+RUN apt-get update && apt-get install -y supervisor nodejs\
   && apt-get clean \
   && apt-get autoremove \
   && rm -rf /var/cache/apt/archives/* \
@@ -16,7 +21,6 @@ RUN apt-get update && apt-get install -y \
     && apt-get autoremove \
     && rm -rf /var/lib/apt/lists/* \
     && rm -rf /var/cache/apt/archives/*
-
 
 RUN pip --no-cache-dir install \
         pydot \
@@ -37,6 +41,10 @@ RUN pip --no-cache-dir install \
         annoy \
     && rm -rf /tmp/* /var/tmp/*
 
+
+# Install and Enable jupyter-widgets
+# jupyterlab-manager@0.35 doesn't work on JL v0.31.12
+RUN jupyter labextension install @jupyter-widgets/jupyterlab-manager@0.34
 
 # Install xgboost
 RUN git clone --recursive https://github.com/dmlc/xgboost \

--- a/dl/dl-base/dl-base-2.x.x.jinja
+++ b/dl/dl-base/dl-base-2.x.x.jinja
@@ -38,6 +38,9 @@ RUN pip --no-cache-dir install \
         tqdm \
         wheel \
         kaggle-cli \
+        kaggle \
+        seaborn \
+        plotly \
         annoy \
     && rm -rf /tmp/* /var/tmp/*
 

--- a/dl/dl-base/dl-base-2.x.x.jinja
+++ b/dl/dl-base/dl-base-2.x.x.jinja
@@ -38,6 +38,7 @@ RUN pip --no-cache-dir install \
         tqdm \
         wheel \
         kaggle \
+        h5py==2.8.0rc1 \
         seaborn \
         plotly \
         annoy \

--- a/dl/dl-base/dl-base-2.x.x.jinja
+++ b/dl/dl-base/dl-base-2.x.x.jinja
@@ -37,7 +37,6 @@ RUN pip --no-cache-dir install \
         spacy \
         tqdm \
         wheel \
-        kaggle-cli \
         kaggle \
         seaborn \
         plotly \

--- a/dl/tensorflow/1.7.0/Dockerfile-py2.gpu.cuda9cudnn7_aws
+++ b/dl/tensorflow/1.7.0/Dockerfile-py2.gpu.cuda9cudnn7_aws
@@ -53,7 +53,6 @@ WORKDIR /
 RUN pip --no-cache-dir install \
         git+git://github.com/fchollet/keras.git@${KERAS_VERSION} \
         tflearn==0.3.2 \
-        h5py==2.8.0rc1 \
     && rm -rf /pip_pkg \
     && rm -rf /tmp/* \
     && rm -rf /root/.cache

--- a/dl/tensorflow/1.7.0/Dockerfile-py2_aws
+++ b/dl/tensorflow/1.7.0/Dockerfile-py2_aws
@@ -46,7 +46,6 @@ WORKDIR /
 RUN pip --no-cache-dir install \
         git+git://github.com/fchollet/keras.git@${KERAS_VERSION} \
         tflearn==0.3.2 \
-        h5py==2.8.0rc1 \
     && rm -rf /pip_pkg \
     && rm -rf /tmp/* \
     && rm -rf /root/.cache

--- a/dl/tensorflow/1.7.0/Dockerfile-py3.gpu.cuda9cudnn7_aws
+++ b/dl/tensorflow/1.7.0/Dockerfile-py3.gpu.cuda9cudnn7_aws
@@ -53,7 +53,6 @@ WORKDIR /
 RUN pip --no-cache-dir install \
         git+git://github.com/fchollet/keras.git@${KERAS_VERSION} \
         tflearn==0.3.2 \
-        h5py==2.8.0rc1 \
     && rm -rf /pip_pkg \
     && rm -rf /tmp/* \
     && rm -rf /root/.cache

--- a/dl/tensorflow/1.7.0/Dockerfile-py3_aws
+++ b/dl/tensorflow/1.7.0/Dockerfile-py3_aws
@@ -46,7 +46,6 @@ WORKDIR /
 RUN pip --no-cache-dir install \
         git+git://github.com/fchollet/keras.git@${KERAS_VERSION} \
         tflearn==0.3.2 \
-        h5py==2.8.0rc1 \
     && rm -rf /pip_pkg \
     && rm -rf /tmp/* \
     && rm -rf /root/.cache

--- a/dl/tensorflow/1.8.0/Dockerfile-py2.gpu.cuda9cudnn7_aws
+++ b/dl/tensorflow/1.8.0/Dockerfile-py2.gpu.cuda9cudnn7_aws
@@ -53,7 +53,6 @@ WORKDIR /
 RUN pip --no-cache-dir install \
         git+git://github.com/fchollet/keras.git@${KERAS_VERSION} \
         tflearn==0.3.2 \
-        h5py==2.8.0rc1 \
     && rm -rf /pip_pkg \
     && rm -rf /tmp/* \
     && rm -rf /root/.cache

--- a/dl/tensorflow/1.8.0/Dockerfile-py2_aws
+++ b/dl/tensorflow/1.8.0/Dockerfile-py2_aws
@@ -46,7 +46,6 @@ WORKDIR /
 RUN pip --no-cache-dir install \
         git+git://github.com/fchollet/keras.git@${KERAS_VERSION} \
         tflearn==0.3.2 \
-        h5py==2.8.0rc1 \
     && rm -rf /pip_pkg \
     && rm -rf /tmp/* \
     && rm -rf /root/.cache

--- a/dl/tensorflow/1.8.0/Dockerfile-py3.gpu.cuda9cudnn7_aws
+++ b/dl/tensorflow/1.8.0/Dockerfile-py3.gpu.cuda9cudnn7_aws
@@ -53,7 +53,6 @@ WORKDIR /
 RUN pip --no-cache-dir install \
         git+git://github.com/fchollet/keras.git@${KERAS_VERSION} \
         tflearn==0.3.2 \
-        h5py==2.8.0rc1 \
     && rm -rf /pip_pkg \
     && rm -rf /tmp/* \
     && rm -rf /root/.cache

--- a/dl/tensorflow/1.8.0/Dockerfile-py3_aws
+++ b/dl/tensorflow/1.8.0/Dockerfile-py3_aws
@@ -46,7 +46,6 @@ WORKDIR /
 RUN pip --no-cache-dir install \
         git+git://github.com/fchollet/keras.git@${KERAS_VERSION} \
         tflearn==0.3.2 \
-        h5py==2.8.0rc1 \
     && rm -rf /pip_pkg \
     && rm -rf /tmp/* \
     && rm -rf /root/.cache

--- a/dl/tensorflow/tensorflow-bazel_aws.jinja
+++ b/dl/tensorflow/tensorflow-bazel_aws.jinja
@@ -64,7 +64,6 @@ WORKDIR /
 RUN pip --no-cache-dir install \
         git+git://github.com/fchollet/keras.git@${KERAS_VERSION} \
         tflearn==0.3.2 \
-        h5py==2.8.0rc1 \
     && rm -rf /pip_pkg \
     && rm -rf /tmp/* \
     && rm -rf /root/.cache


### PR DESCRIPTION
In order to install and enable widget extension, JL requires Nodejs > v5.x.

Here are the new packages:
- nodejs v8.x
- jupyter-widget
- seaborn (visualization)
- plotly (visualization)
- kaggle (official)
