### PR TITLE
New Envs: Pytorch 0.4.1, TF 1.10

### DIFF
--- a/dl/dl-base/3.1.0/Dockerfile-py2
+++ b/dl/dl-base/3.1.0/Dockerfile-py2
@@ -39,7 +39,7 @@ RUN pip --no-cache-dir install \
         tqdm \
         wheel \
         kaggle \
-        h5py==2.8.0rc1 \
+        h5py \
         seaborn \
         plotly \
         annoy \

--- a/dl/dl-base/3.1.0/Dockerfile-py2
+++ b/dl/dl-base/3.1.0/Dockerfile-py2
@@ -39,7 +39,7 @@ RUN pip --no-cache-dir install \
         tqdm \
         wheel \
         kaggle \
-        h5py \
+        h5py==2.8.0 \
         seaborn \
         plotly \
         annoy \

--- a/dl/dl-base/3.1.0/Dockerfile-py2.gpu
+++ b/dl/dl-base/3.1.0/Dockerfile-py2.gpu
@@ -39,7 +39,7 @@ RUN pip --no-cache-dir install \
         tqdm \
         wheel \
         kaggle \
-        h5py==2.8.0rc1 \
+        h5py \
         seaborn \
         plotly \
         annoy \

--- a/dl/dl-base/3.1.0/Dockerfile-py2.gpu
+++ b/dl/dl-base/3.1.0/Dockerfile-py2.gpu
@@ -39,7 +39,7 @@ RUN pip --no-cache-dir install \
         tqdm \
         wheel \
         kaggle \
-        h5py \
+        h5py==2.8.0 \
         seaborn \
         plotly \
         annoy \

--- a/dl/dl-base/3.1.0/Dockerfile-py3
+++ b/dl/dl-base/3.1.0/Dockerfile-py3
@@ -38,7 +38,7 @@ RUN pip --no-cache-dir install \
         tqdm \
         wheel \
         kaggle \
-        h5py \
+        h5py==2.8.0 \
         seaborn \
         plotly \
         annoy \

--- a/dl/dl-base/3.1.0/Dockerfile-py3
+++ b/dl/dl-base/3.1.0/Dockerfile-py3
@@ -38,7 +38,7 @@ RUN pip --no-cache-dir install \
         tqdm \
         wheel \
         kaggle \
-        h5py==2.8.0rc1 \
+        h5py \
         seaborn \
         plotly \
         annoy \

--- a/dl/dl-base/3.1.0/Dockerfile-py3.gpu
+++ b/dl/dl-base/3.1.0/Dockerfile-py3.gpu
@@ -38,7 +38,7 @@ RUN pip --no-cache-dir install \
         tqdm \
         wheel \
         kaggle \
-        h5py \
+        h5py==2.8.0 \
         seaborn \
         plotly \
         annoy \

--- a/dl/dl-base/3.1.0/Dockerfile-py3.gpu
+++ b/dl/dl-base/3.1.0/Dockerfile-py3.gpu
@@ -38,7 +38,7 @@ RUN pip --no-cache-dir install \
         tqdm \
         wheel \
         kaggle \
-        h5py==2.8.0rc1 \
+        h5py \
         seaborn \
         plotly \
         annoy \

--- a/dl/dl-base/dl-base-2.x.x.jinja
+++ b/dl/dl-base/dl-base-2.x.x.jinja
@@ -41,7 +41,7 @@ RUN pip --no-cache-dir install \
         tqdm \
         wheel \
         kaggle \
-        h5py==2.8.0rc1 \
+        h5py \
         seaborn \
         plotly \
         annoy \

--- a/dl/dl-base/dl-base-2.x.x.jinja
+++ b/dl/dl-base/dl-base-2.x.x.jinja
@@ -41,7 +41,7 @@ RUN pip --no-cache-dir install \
         tqdm \
         wheel \
         kaggle \
-        h5py \
+        h5py==2.8.0 \
         seaborn \
         plotly \
         annoy \

--- a/dl/pytorch/0.4.1/Dockerfile-py2
+++ b/dl/pytorch/0.4.1/Dockerfile-py2
@@ -1,0 +1,11 @@
+FROM floydhub/tensorflow:1.7.0-py2_aws.31
+MAINTAINER Floyd Labs "support@floydhub.com"
+
+RUN pip --no-cache-dir install --upgrade http://download.pytorch.org/whl/cu91/torch-0.4.1-cp27-cp27mu-linux_x86_64.whl \
+    torchvision==0.2.1
+
+
+
+RUN pip --no-cache-dir install --upgrade \
+torchtext \
+tensorboardX==1.2

--- a/dl/pytorch/0.4.1/Dockerfile-py2
+++ b/dl/pytorch/0.4.1/Dockerfile-py2
@@ -5,7 +5,6 @@ RUN pip --no-cache-dir install --upgrade http://download.pytorch.org/whl/cu91/to
     torchvision==0.2.1
 
 
-
 RUN pip --no-cache-dir install --upgrade \
 torchtext \
 tensorboardX==1.2

--- a/dl/pytorch/0.4.1/Dockerfile-py2.gpu.cuda9cudnn7
+++ b/dl/pytorch/0.4.1/Dockerfile-py2.gpu.cuda9cudnn7
@@ -1,0 +1,11 @@
+FROM floydhub/tensorflow:1.7.0-gpu.cuda9cudnn7-py2_aws.31
+MAINTAINER Floyd Labs "support@floydhub.com"
+
+RUN pip --no-cache-dir install --upgrade http://download.pytorch.org/whl/cu91/torch-0.4.1-cp27-cp27mu-linux_x86_64.whl \
+    torchvision==0.2.1
+
+
+
+RUN pip --no-cache-dir install --upgrade \
+torchtext \
+tensorboardX==1.2

--- a/dl/pytorch/0.4.1/Dockerfile-py2.gpu.cuda9cudnn7
+++ b/dl/pytorch/0.4.1/Dockerfile-py2.gpu.cuda9cudnn7
@@ -5,7 +5,6 @@ RUN pip --no-cache-dir install --upgrade http://download.pytorch.org/whl/cu91/to
     torchvision==0.2.1
 
 
-
 RUN pip --no-cache-dir install --upgrade \
 torchtext \
 tensorboardX==1.2

--- a/dl/pytorch/0.4.1/Dockerfile-py3
+++ b/dl/pytorch/0.4.1/Dockerfile-py3
@@ -1,0 +1,11 @@
+FROM floydhub/tensorflow:1.7.0-py3_aws.31
+MAINTAINER Floyd Labs "support@floydhub.com"
+
+RUN pip --no-cache-dir install --upgrade http://download.pytorch.org/whl/cu91/torch-0.4.1-cp36-cp36m-linux_x86_64.whl \
+    torchvision==0.2.1
+
+
+
+RUN pip --no-cache-dir install --upgrade \
+torchtext \
+tensorboardX==1.2

--- a/dl/pytorch/0.4.1/Dockerfile-py3
+++ b/dl/pytorch/0.4.1/Dockerfile-py3
@@ -5,7 +5,6 @@ RUN pip --no-cache-dir install --upgrade http://download.pytorch.org/whl/cu91/to
     torchvision==0.2.1
 
 
-
 RUN pip --no-cache-dir install --upgrade \
 torchtext \
 tensorboardX==1.2

--- a/dl/pytorch/0.4.1/Dockerfile-py3.gpu.cuda9cudnn7
+++ b/dl/pytorch/0.4.1/Dockerfile-py3.gpu.cuda9cudnn7
@@ -1,0 +1,11 @@
+FROM floydhub/tensorflow:1.7.0-gpu.cuda9cudnn7-py3_aws.31
+MAINTAINER Floyd Labs "support@floydhub.com"
+
+RUN pip --no-cache-dir install --upgrade http://download.pytorch.org/whl/cu91/torch-0.4.1-cp36-cp36m-linux_x86_64.whl \
+    torchvision==0.2.1
+
+
+
+RUN pip --no-cache-dir install --upgrade \
+torchtext \
+tensorboardX==1.2

--- a/dl/pytorch/0.4.1/Dockerfile-py3.gpu.cuda9cudnn7
+++ b/dl/pytorch/0.4.1/Dockerfile-py3.gpu.cuda9cudnn7
@@ -5,7 +5,6 @@ RUN pip --no-cache-dir install --upgrade http://download.pytorch.org/whl/cu91/to
     torchvision==0.2.1
 
 
-
 RUN pip --no-cache-dir install --upgrade \
 torchtext \
 tensorboardX==1.2

--- a/dl/pytorch/matrix.yml
+++ b/dl/pytorch/matrix.yml
@@ -147,9 +147,17 @@
     _tensorboardx_version: 1.2
     _test: tests/0.3.1/run.sh
 
+'0.4.1':
+  - <<: *pytorch_cuda_9_1
+    _version: 0.4.1
+    _vision_version: 0.2.1
+    _tensorboardx_version: 1.2
+    _test: tests/0.3.1/run.sh
+
 $render:
   #- '0.1.12'
   #- '0.2.0'
   # - '0.3.0'
-  - '0.3.1'
-  - '0.4.0'
+  # - '0.3.1'
+  # - '0.4.0'
+  - '0.4.1'

--- a/dl/pytorch/pytorch-0.x.x.jinja
+++ b/dl/pytorch/pytorch-0.x.x.jinja
@@ -14,10 +14,8 @@ RUN git clone https://github.com/pytorch/vision \
     && rm -rf vision
 {% endif %}
 
-{% if _tensorboardx_version is defined %}
 RUN pip --no-cache-dir install --upgrade \
 torchtext {% if _tensorboardx_version is defined %}\
 tensorboardX=={{_tensorboardx_version}}{% endif %}
-{% endif %}
 
 {%- endblock %}

--- a/dl/pytorch/pytorch-0.x.x.jinja
+++ b/dl/pytorch/pytorch-0.x.x.jinja
@@ -15,7 +15,9 @@ RUN git clone https://github.com/pytorch/vision \
 {% endif %}
 
 {% if _tensorboardx_version is defined %}
-RUN pip --no-cache-dir install --upgrade tensorboardX=={{_tensorboardx_version}}
+RUN pip --no-cache-dir install --upgrade \
+torchtext {% if _tensorboardx_version is defined %}\
+tensorboardX=={{_tensorboardx_version}}{% endif %}
 {% endif %}
 
 {%- endblock %}

--- a/dl/tensorflow/matrix.yml
+++ b/dl/tensorflow/matrix.yml
@@ -170,14 +170,21 @@ tensorflow_aws: &tensorflow_aws
     _keras_version: 2.2.0
     _test: tests/1.7.0/run.sh
 
+1.10.0:
+  - <<: *aws_cuda9_1
+    _version: v1.10.0
+    _keras_version: 2.2.2
+    _test: tests/1.7.0/run.sh
+
 $render:
   # - 0.12.1
   # - 1.0.1
   # - 1.1.0
   # - 1.2.1
   # - 1.3.1
-  - 1.4.0
-  - 1.5.0
-  - 1.7.0
-  - 1.8.0
-  - 1.9.0
+  # - 1.4.0
+  # - 1.5.0
+  # - 1.7.0
+  # - 1.8.0
+  # - 1.9.0
+  - 1.10.0


### PR DESCRIPTION
hey @houqp, before merging this PR we need to rebuild the base from `nvidia/cuda:9.2-cudnn7-devel-ubuntu16.04`

What's new on this PR:
- Added `Pytorch` v0.4.1
- Added `Torchtext` on the pytorch envs
- Use latest `h5py` in dl-base to fix python 2. compatibility issue (see this [thread](https://forum.floydhub.com/t/cannot-save-keras-model-h5py-import-errors/1018)) 